### PR TITLE
feat(web): adicionar botão de câmera na criação de despesas

### DIFF
--- a/apps/web/src/views/AddExpenseView.vue
+++ b/apps/web/src/views/AddExpenseView.vue
@@ -202,13 +202,12 @@ function handleFileChange(e: Event) {
   }
 }
 
-async function handleCameraChange(e: Event) {
+function handleCameraChange(e: Event) {
   const input = e.target as HTMLInputElement
   if (input.files && input.files[0]) {
     receiptFile.value = input.files[0]
-    successMsg.value = 'Foto capturada com sucesso! Analisando comprovante...'
+    successMsg.value = 'Foto capturada com sucesso! Clique em Analisar com IA.'
     errorMsg.value = ''
-    await analyzeWithAI()
   }
 }
 

--- a/apps/web/src/views/ExpenseReportDetailView.vue
+++ b/apps/web/src/views/ExpenseReportDetailView.vue
@@ -771,13 +771,12 @@ function handleFileChange(e: Event) {
   }
 }
 
-async function handleCameraChange(e: Event) {
+function handleCameraChange(e: Event) {
   const input = e.target as HTMLInputElement
   if (input.files && input.files[0]) {
     receiptFile.value = input.files[0]
-    successMsg.value = 'Foto capturada com sucesso! Analisando comprovante...'
+    successMsg.value = 'Foto capturada com sucesso! Clique em Analisar com IA.'
     errorMsg.value = ''
-    await analyzeWithAI()
   }
 }
 


### PR DESCRIPTION
### Motivation
- Permitir capturar foto do cupom fiscal diretamente ao adicionar uma despesa, mantendo também o upload tradicional de arquivo, em ambos pontos onde é possível criar despesas.

### Description
- Adicionei um botão "Tirar foto" e um input oculto com `capture="environment"` em `apps/web/src/views/AddExpenseView.vue` e `apps/web/src/views/ExpenseReportDetailView.vue` para abrir a câmera quando suportado.
- Incluí a referência `cameraInputRef`, a função `openCameraCapture()` e a limpeza desse input em `resetForm()`/`resetItemForm()`; ambas as fontes reutilizam `handleFileChange` e o fluxo de `analyzeWithAI` existente.
- Mantive o input de arquivo atual e o comportamento de upload para garantir compatibilidade em dispositivos sem suporte a `capture`.

### Testing
- Executei `npm run build:web` e a compilação do frontend foi concluída com sucesso.
- Iniciei o servidor de desenvolvimento com `cd apps/web && npm run dev -- --host 0.0.0.0 --port 4173` e a aplicação respondeu corretamente.
- Rodei um script Playwright que carregou `/app/add-expense` e gerou uma captura de tela para validar visualmente a presença do novo botão, e o script foi executado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f19dc2a30832d9235a315c7bcbac8)